### PR TITLE
Fix maximum international reference length to 24

### DIFF
--- a/src/finnish-bank-utils.js
+++ b/src/finnish-bank-utils.js
@@ -2,7 +2,7 @@
 
 const
   REF_NUMBER_MULTIPLIERS = [7, 3, 1],
-  FINNISH_REF_NUMBER_REGEX = /^(\d{4,20}|RF\d{6,23})$/i,
+  FINNISH_REF_NUMBER_REGEX = /^(\d{4,20}|RF\d{6,22})$/i,
   FINNISH_IBAN_REGEX = /^FI\d{16}$/,
   FINNISH_VIRTUAL_BAR_CODE_REGEX = /^[45]\d{53}$/,
   FINNISH_DATE_REGEX = /^(\d\d?)\.(\d\d?)\.(\d{4})$/,


### PR DESCRIPTION
Source: https://fi.wikipedia.org/wiki/Tilisiirto#Viitenumero

Also, since the finnish reference is maximum 20 chars, adding "RF" + 2-digit checksum in front adds up to 24.