### PR TITLE
Remove unreachable bad return statement

### DIFF
--- a/src/finnish-bank-utils.js
+++ b/src/finnish-bank-utils.js
@@ -375,8 +375,6 @@ const FinnishBankUtils = {
       + leftPadString(String(year).substr(-2), '0', 2)
       + leftPadString(String(month), '0', 2)
       + leftPadString(String(day), '0', 2)
-
-    return {iban, sum, reference, date}
   }
 
 }


### PR DESCRIPTION
The first return statement seems to match the expected outcome; removing the second one which causes warning in browser console about unreachable code.