### PR TITLE
Support shortest possible finnish reference number in international format.

### DIFF
--- a/src/finnish-bank-utils.js
+++ b/src/finnish-bank-utils.js
@@ -2,7 +2,7 @@
 
 const
   REF_NUMBER_MULTIPLIERS = [7, 3, 1],
-  FINNISH_REF_NUMBER_REGEX = /^(\d{4,20}|RF\d{6,22})$/i,
+  FINNISH_REF_NUMBER_REGEX = /^(\d{4,20}|RF\d{4,22})$/i,
   FINNISH_IBAN_REGEX = /^FI\d{16}$/,
   FINNISH_VIRTUAL_BAR_CODE_REGEX = /^[45]\d{53}$/,
   FINNISH_DATE_REGEX = /^(\d\d?)\.(\d\d?)\.(\d{4})$/,


### PR DESCRIPTION
A finnish reference number is at least 4 digits, but as I see it the spec doesn't prohibit the first numbers being zero. The smallest non-zero finnish reference would thus be 0013. The rules for converting finnish reference number to international "Creditor Reference" RF format also state that initial zeroes should be removed before embedding, thus yielding RF41 13 as the shortest finnish refernce in RF format (rather than RF41 0013). Thus this PR updates the regex to allow for a minimum of RF + 4 digits instead of RF + 6 digits.

See http://www.finanssiala.fi/maksujenvalitys/dokumentit/kansainvalisen_viitteen_rakenneohje.pdf