### PR TITLE
Typescript declaration file + typo fix in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ FinnishBankUtils.generateFinnishRefNumber('617367284')
 
 ```js
 # Generate a Finnish IBAN
-FinnishBankUtils.generateFinnishRefIBAN()
+FinnishBankUtils.generateFinnishIBAN()
 // 'FI9080002627761348'
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "Pankkiviidakoodi",
     "Virtuaaliviivakoodi"
   ],
+  "types": "./types/finnish-bank-utils-types.d.ts",
   "author": "vkomulai <ville.komulainen@iki.fi>",
   "contributors": [
     "Sakari Tuominen",

--- a/types/finnish-bank-utils-types.d.ts
+++ b/types/finnish-bank-utils-types.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for finnish-bank-utils 1.3.3
+// Project: https://github.com/vkomulai/finnish-bank-utils
+// Defintitions by Ashley K. Smith https://github.com/ashksmith
+
+export function isValidFinnishRefNumber(referenceNumber: string): boolean;
+export function isValidFinnishIBAN(ibanNumber: string): boolean;
+export function formatFinnishRefNumber(referenceNumber: string): string;
+export function formatFinnishIBAN(ibanNumber: string): string;
+export function formatFinnishVirtualBarCode(barCode: {iban: string; sum: number; reference: string; date: string; }): string;
+export function parseFinnishVirtualBarCode(barCode: string): { iban: string; sum: number; reference: string; date: string };
+export function generateFinnishRefNumber(initial?: string): string;
+export function generateFinnishIBAN(): string;


### PR DESCRIPTION
I'm using this npm package in a Typescript project I'm working with; This is the declaration file I'm using. There is also a typo in one of the function names in the readme. 